### PR TITLE
Responsive WebApp (mínimo): viewport-fit + safe-area + iconos/título responsivos

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico?v=3" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico?v=3" />
     <link rel="apple-touch-icon" href="/favicon.ico?v=3" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>MindFit - Fitness App</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2781,7 +2781,9 @@ const AppContent = () => {
           <Route path="/video-correction" element={<VideoCorrectionSection />} />
           <Route path="/openai-test" element={<OpenAITest />} />
         </Routes>
-        <Navigation />
+        <div className="safe-bottom">
+          <Navigation />
+        </div>
         <MusicBubble />
       </div>
     </UserProvider>

--- a/src/components/HomeTrainingSection.jsx
+++ b/src/components/HomeTrainingSection.jsx
@@ -391,21 +391,21 @@ const HomeTrainingSection = () => {
   const equipmentLevels = {
     minimal: {
       name: 'Equipamiento Mínimo',
-      icon: <Home className="w-5 h-5" />,
+      icon: <Home className="w-5 h-5 sm:w-6 sm:h-6" />,
       equipment: ['Peso corporal', 'Toallas', 'Silla/Sofá', 'Pared'],
       workouts: ['Flexiones variadas', 'Sentadillas', 'Plancha', 'Burpees'],
       color: 'border-green-400'
     },
     basic: {
       name: 'Equipamiento Básico',
-      icon: <Dumbbell className="w-5 h-5" />,
+      icon: <Dumbbell className="w-5 h-5 sm:w-6 sm:h-6" />,
       equipment: ['Mancuernas ajustables', 'Bandas elásticas', 'Esterilla', 'Banco/Step'],
       workouts: ['Press de pecho', 'Remo con banda', 'Peso muerto', 'Curl bíceps'],
       color: 'border-yellow-400'
     },
     advanced: {
       name: 'Equipamiento Avanzado',
-      icon: <Target className="w-5 h-5" />,
+      icon: <Target className="w-5 h-5 sm:w-6 sm:h-6" />,
       equipment: ['Barra dominadas', 'Kettlebells', 'TRX', 'Discos olímpicos'],
       workouts: ['Dominadas', 'Swing kettlebell', 'Sentadilla goblet', 'Turkish get-up'],
       color: 'border-red-400'
@@ -460,7 +460,7 @@ const HomeTrainingSection = () => {
     <div className="min-h-screen bg-black text-white p-6 pb-24">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-yellow-400 to-yellow-200 bg-clip-text text-transparent">
+          <h1 className="font-bold mb-4 bg-gradient-to-r from-yellow-400 to-yellow-200 bg-clip-text text-transparent" style={{ fontSize: 'clamp(1.5rem, 3.5vw, 2.25rem)' }}>
             Entrenamiento en Casa
           </h1>
           <p className="text-xl text-gray-300 max-w-3xl mx-auto">


### PR DESCRIPTION
Este PR aplica ajustes mínimos para que la WebApp se adapte mejor a móvil (iOS/Android) y desktop, sin introducir dependencias nuevas:

Cambios:
- index.html: meta viewport con `viewport-fit=cover` para soportar safe areas en iOS.
- src/App.css: clase `.safe-bottom` para respetar env(safe-area-inset-bottom) en barras fijas inferiores.
- src/App.jsx: envuelve `<Navigation />` con `safe-bottom` para que no quede solapada con la zona de gestos/notch.
- src/components/HomeTrainingSection.jsx: iconos Lucide con tamaños responsivos (w-5→sm:w-6) y título con `clamp(...)` para escalar mejor entre móvil y desktop.

Motivación:
- Mejor legibilidad y usabilidad táctil en móviles, sin alterar el diseño base.
- Evita recortes en iPhone con notch/gestos.

Notas:
- No se tocaron lógicas ni endpoints.
- Si gusta el resultado, puedo replicar el patrón (iconos/títulos) en 2–3 pantallas más clave.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author